### PR TITLE
Rebuild ieee802_11 and inspector against fmt 11.0

### DIFF
--- a/recipes/ieee802-11/recipe.yaml
+++ b/recipes/ieee802-11/recipe.yaml
@@ -10,7 +10,7 @@ context:
   base_version: "0.0.0"
   date_str: "20250304"
   version: ${{ base_version }}.${{ date_str }}.dev+g${{ git_rev[:7] }}
-  build: "1"
+  build: "2"
 
 package:
   name: ${{ name|lower }}

--- a/recipes/inspector/recipe.yaml
+++ b/recipes/inspector/recipe.yaml
@@ -10,7 +10,7 @@ context:
   base_version: "0.0.0"
   date_str: "20250303"
   version: ${{ base_version }}.${{ date_str }}.dev+g${{ git_rev[:7] }}
-  build: "1"
+  build: "2"
 
 package:
   name: ${{ name|lower }}


### PR DESCRIPTION
fmt 11.1 has been pulled from conda-forge due to ABI breakage, so prior versions which may have built against it are not installable.